### PR TITLE
bower.json: set ignore property to array of strings

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "jwt-js",
   "version": "1.0.1",
   "main": "./src/jwt-token.js",
-  "ignore": "tests",
+  "ignore": ["tests"],
   "homepage": "https://github.com/hodrigohamalho/jwt-js",
   "authors": [
     "Michael Hanson <mhanson@mozilla.com>"


### PR DESCRIPTION
Bower failed to install this package because it was trying to include the 'tests' directory. The 'ignore' setting in bower.json should be an array of strings; changing this allowed the package to be installed. 
